### PR TITLE
update load function

### DIFF
--- a/src/data.jl
+++ b/src/data.jl
@@ -72,7 +72,10 @@ function load(id::Int; maxbytes = nothing)
         @info "Downloading dataset $id."
         download(load_Dataset_Description(id)["data_set_description"]["url"], fname)
     end
-    ARFFFiles.load(x -> ARFFFiles.readcolumns(x; maxbytes = maxbytes), fname)
+    open(fname) do io
+        reader = ARFFFiles.loadstreaming(io)
+        return ARFFFiles.readcolumns(reader; maxbytes=maxbytes)
+    end
 end
 
 


### PR DESCRIPTION
recent updates to ARFFFiles.jl broke the `load` functionality for data sets.
This patch fixes the load function to make it work again.

fixes #29 